### PR TITLE
Demo page and cellContent

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,14 @@ options: {
 
 #### Select a cell
 ```javascript
+// Selecting a cell returns the <td> HTMLElement
+// Note: row and col are 0-index based, so (0,0) corresponds to "A1"
 myTable.selectCell(0,0); // select the cell in the top-left most corner
-myTable._("G7"); // select the cell in column G, row 7
+
+// Getting cell content can be done by using the below function
+// Recommendation: Use the cell name when calling cellContent. While the 0-index based coordinates may be given, it can be more confusing and may lead to off-by-one errors
+myTable.cellContent("G7"); // select the cell in column G, row 7
+myTable.cellContent(6, 6); // select the cell in (6, 6), AKA "G7"
 ```
 Note that when selecting cells, you may only select "content cells". That is, it is not possible to select the header cells marked by letters or the row numberings. These are included with .getRows and .getCols, however:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Spreadsheet.js
 _A small javascript library for creating spreadsheet style tables_
 
+[![](https://img.shields.io/badge/Demo-Live%20Demo-brightgreen.svg?style=flat-square)](https://chiefofgxbxl.github.io/Spreadsheet.js/) [![](https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)](http://opensource.org/licenses/MIT)
 
 ## Features
  * Create tables, large and small

--- a/bin/Spreadsheet.js
+++ b/bin/Spreadsheet.js
@@ -217,23 +217,26 @@ function Spreadsheet(options) {
     };
     
     this.cellContent = function(row, col) {
-        return this.table.children[row+1].children[col+1].textContent;
-    };
-    
-    this._ = function(cellname) {
-        var cell = parseCellname(cellname),
-            letterPart,
-            digitPart;
-        
-        if(cell[1].length > 2) {
-            return; // Spreadsheet.js only supports cellnames up to ZZ (which is 702 columns!)
+        if(arguments.length === 2 && typeof arguments[0] === 'number' && typeof arguments[1] === 'number') {
+            // Row and col provided
+            return this.table.tBodies[0].children[row].children[col+1].textContent;
         }
-        
-        // ex. [A, 4] or [ZZ, 210]
-        letterPart = letterBaseToNum(cell[0]);
-        digitPart = cell[1];
-        
-        return this.cellContent(digitPart-1, letterPart-1);
+        else if(arguments.length === 1 && typeof arguments[0] === 'string') {
+            // Cellname provided, e.g. "G15"
+            var cell = parseCellname(arguments[0]), // e.g. [A, 4] or [ZZ, 157]
+                letterPart = letterBaseToNum(cell[0]),
+                digitPart = cell[1];
+            
+            if(cell[0].length > 2) { // check the length of the column
+                return; // Spreadsheet.js only supports cellnames up to ZZ (which is 702 columns!)
+            }
+            
+            return this.cellContent(digitPart-1, letterPart-1);
+        }
+        else {
+            // Unsupported arguments supplied to this function call
+            console.warn('Invalid arguments supplied to cellContent: Expected (<int> row, <int> col) OR (<string> cellname)');
+        }
     };
     
     // this.tabulateData = function() {} // output data in a useful form, ex. CSV


### PR DESCRIPTION
Closed two issues which added new features. The first addition is the gh-pages branch to host a live demo page so users can play around with the Spreadsheet without having to download it and set it up. Second is the cellContent function, which was merged with _ to either take a cellname or coordinates.
