### PR TITLE
Populate spreadsheet with data via option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ options: {
 #### Populate spreadsheet with data
 A spreadsheet can be automatically populated with values by using the *data* option. This is done by providing an array of arrays. The children arrays each present a row in the table, with the elements corresponding to columns.
 
-E.g. ```javascript
+E.g. 
+```javascript
 [
 	[1,2,3],
 	[4,5,6],

--- a/README.md
+++ b/README.md
@@ -34,11 +34,13 @@ By default, cells will not be filled in with any data. If you'd like it to add s
 ![](https://github.com/ChiefOfGxBxL/Spreadsheet.js/blob/master/screenshots/Spreadsheet_Basic.PNG)
 
 #### Options
-Below are all of the options that can be specified when creating a spreadsheet, including event-handlers and table information. **Options preceded by an asterisk (*) are required**!
+Below are all of the options that can be specified when creating a spreadsheet, including spreadsheet size, data, and event-handlers. **Options preceded by an asterisk (*) are required**! 
+
 ```javascript
 options: {
     *rows: <Integer>,
     *cols: <Integer>,
+    data: <Array<Array>> // overrides rows and cols if present
     *context: <HTMLElement>,
     
     autofill: <Boolean>,
@@ -52,6 +54,18 @@ options: {
     onNewCol: <function()>
 }
 ```
+
+#### Populate spreadsheet with data
+A spreadsheet can be automatically populated with values by using the *data* option. This is done by providing an array of arrays. The children arrays each present a row in the table, with the elements corresponding to columns.
+
+E.g. ```javascript
+[
+	[1,2,3],
+	[4,5,6],
+	[7,8,9]
+]
+```
+creates a spreadsheet with three rows and three columns. Row one will contain the values 1,2,3, row two: 4,5,6, and row three: 7,8,9. The spreadsheet will be sized accordingly, and will always be large enough to hold the data, leaving other cells blank if needed.
 
 #### Select a cell
 ```javascript

--- a/bin/Spreadsheet.js
+++ b/bin/Spreadsheet.js
@@ -25,13 +25,20 @@ function Spreadsheet(options) {
     
     
     // Private variables
-    var _rowCount = options.rows,
-        _colCount = options.cols,
+    var _rowCount = (options.data) ? options.data.length : options.rows,
+        _colCount = (options.data) ? (function() {
+            var longestRow = 0;
+            options.data.forEach(function(row) {
+                if(row.length > longestRow) {
+                    longestRow = row.length;
+                }
+            });
+            return longestRow;
+        })() : options.cols,
         _rowCounter = 0, // for labeling the rows with their row number
         _alphabet = ' ABCDEFGHIJKLMNOPQRSTUVWXYZ',
         self = this, // set to this object; allows functions to bypass functional scope and access the Spreadsheet
         oldCellValue; // used to track value for event handler onCellValueChanged
-    
     
     // Private functions
     function tdDblClick(e) {
@@ -173,7 +180,6 @@ function Spreadsheet(options) {
         }
         
         this.table.tBodies[0].appendChild(tr);
-        _rowCount += 1;
         
         this.onNewRow();
     };
@@ -371,12 +377,14 @@ function Spreadsheet(options) {
             grayCell = document.createElement('th'),
             th,
             i,
-            r;
+            r,
+            dataRow,
+            dataCol;
             
         grayCell.innerHTML = ' ';
         
         tr.appendChild(grayCell);
-        for(i = 0; i < options.cols; i++) {
+        for(i = 0; i < _colCount; i++) {
             th = document.createElement('th');
             th.innerHTML = numToLetterBase(i+1);
             tr.appendChild(th);
@@ -387,8 +395,18 @@ function Spreadsheet(options) {
         table.appendChild(tbody);
         
         // add rest of rows; self.addRow will add each new row to the <tbody>
-        for(r = 0; r < options.rows; r++) {
+        for(r = 0; r < _rowCount; r++) {
             self.addRow();
+        }
+        
+        // If data is provided, populate the spreadsheet with its values
+        if(options.data) {
+            for(dataRow = 0; dataRow < options.data.length; dataRow++) {
+                // populate each row in the table
+                for(dataCol = 0; dataCol < _colCount; dataCol++) {
+                    tbody.children[dataRow].children[dataCol+1].innerHTML = (options.data[dataRow] && options.data[dataRow][dataCol]) ? options.data[dataRow][dataCol] : '';
+                }
+            }
         }
         
         c.appendChild(table);

--- a/demo/demo.html
+++ b/demo/demo.html
@@ -19,7 +19,19 @@
                 autofill: true
             });
 			
-			myTable2 = new Spreadsheet({rows: 2, cols: 3, context: container2});
+			myTable2 = new Spreadsheet({
+                context: container2, 
+                data: [
+                    [1,2],
+                    [4,5,6],
+                    [7,8,9],
+                    [1,2,3,4,5,6,7],
+                    [1,2,3,5,5],
+                    []
+                ],
+                autofill: true
+            });
+            
 			myTable3 = new Spreadsheet({rows: 0, cols: 0, context: container3});
 		}
 	</script>


### PR DESCRIPTION
Added the `data` field to options, which gives the choice to populate the spreadsheet with values when it is created. `data` overrides rows and cols, making an appropriately sized spreadsheet to fit all the values. It is also unaffected by the `autofill` option.
